### PR TITLE
Changed title of lab 9

### DIFF
--- a/labs/Lab09.qmd
+++ b/labs/Lab09.qmd
@@ -1,5 +1,5 @@
 ---
-title: "ENVX1002 Practical Topic 9 - Describing relationships"
+title: Lab 9 - Describing relationships
 embed-resources: true
 ---
 
@@ -13,9 +13,7 @@ pacman::p_load(tidyverse, readxl, knitr, kableExtra)
 <br>
 
 ::: callout-tip
-
-
-### Objectives
+### Learning Outcomes
 
 * Calculate and interpret Correlation Coefficients in Excel and R
 * Produce scatterplots in Excel and R

--- a/labs/Lab10.qmd
+++ b/labs/Lab10.qmd
@@ -11,7 +11,7 @@ pacman::p_load(readxl)
 
 
 ::: callout-tip
-### Objectives
+### Learning Outcomes
 
 -   Fit simple linear models and obtain associated model summaries in R
 -   Overlay fitted models onto scatterplots in R


### PR DESCRIPTION
Updated banners in call out tip boxes so they say "learning outcomes" instead of "objectives", and title of lab 9 so it's all consistent